### PR TITLE
Allow right-hand reference via "[]"

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ jetpt_in_gev = df.jets[df.jets.ptgev > 30].ptgev
 
 The prototype implementation is particularly fragile - but that is due to poor design rather than a technical limitation.
 
+You can also refer to a leaf using a simple syntax. For example, `df.jets["ptgev"]` and `df.jets.ptgev` are the same on the right hand side of an expression. `df.xxx` and `df["xxx"]` are equivalent in all circumstances.
+
 ### Adding to the data model using objects
 
 Another way to do this is build an object. For example, lets say you want to make it easy to do 3-vector operations. You might write something like this:

--- a/tests/test_computed_col.py
+++ b/tests/test_computed_col.py
@@ -18,6 +18,15 @@ def test_create_col_with_text():
     assert ast.dump(d1.child_expr) == "BinOp(left=ast_DataFrame(), op=Div(), right=Num(n=1000))"
 
 
+def test_create_col_access_with_text():
+    df = DataFrame()
+    df.jets['ptgev'] = df.jets.pt / 1000
+    d1 = df.jets['ptgev']
+
+    assert d1.child_expr is not None
+    assert ast.dump(d1.child_expr) == "BinOp(left=ast_DataFrame(), op=Div(), right=Num(n=1000))"
+
+
 def test_create_col_twice():
     df = DataFrame()
     df.jets['ptgev'] = df.jets.pt / 1000.0


### PR DESCRIPTION
Allows one to make a right-handed reference to a leaf - `df.jets.pt` and `df.jets["pt"]` are the same thing now.

Fixes #8