### PR TITLE
Fix up empty warning message (fixes #12)

### DIFF
--- a/dataframe_expressions/data_frame.py
+++ b/dataframe_expressions/data_frame.py
@@ -239,7 +239,7 @@ class DataFrame:
             if not self._sub_df[key].computed_col:
                 raise Exception(f'You may not redefine "{key}".')
             else:
-                logging.getLogger(__name__).warning('')
+                logging.getLogger(__name__).warning(f'Redefinition of DataFrame item "{key}"')
 
         self._sub_df[key] = _sub_link_info(expr, True)
         return self

--- a/tests/test_computed_col.py
+++ b/tests/test_computed_col.py
@@ -126,6 +126,13 @@ def test_create_col_with_lambda():
     assert cast(ast_Callable, d1.child_expr.func).dataframe is p
 
 
+def test_create_col_with_lambda_twice():
+    df = DataFrame()
+    df.jets['ptgev'] = lambda j: j.pt / 1000
+    df.jets['ptgev'] = lambda j: j.pt / 1001
+    _ = df.jets.ptgev
+
+
 def test_col_twice_nested():
     df = DataFrame()
     df.jets['ptgev'] = lambda j: j.pt / 1000.0


### PR DESCRIPTION
- Update an empty warning message to have some actual text in it
- Add tests to make sure re-definition of items in data_frames causes no problems.

Addresses #19
