### PR TITLE
Adds numpy array function support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
         "dfattr",
         "dfattrattr",
         "eles",
+        "elts",
         "firstlineno",
         "funcs",
         "inuse",

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ d1 = abs(d.x)
 
 Internally, this is rendered as `d.x.sin()`. The `numpy` functions are translated directly into calls like this - it is up to whatever backend you have to actually implement them. For the complete list of `numpy` functions, see the [`numpy` math page](https://numpy.org/doc/stable/reference/routines.math.html).
 
+Finally, other `numpy` functions - `array_functions` are also translated. For example:
+
+```python
+h = np.histogram(d.x, bins=50, range=(-0.5,10))
+```
+
+creates a `DataFrame` which makes a call to the `np_histogram` function. A backend can then implement that function.
+
+One of the most useful extra expressions in a functional language is the `if-then-else` expression. In python this is `a if a > b else b`. Unfortunately, due to the way the python interpreter works, we can't use this directly with `DataFrame`s. Instead, we can use the `np.where` 3-argument function. `np.where(<test>, <test-true-result>, <test-false-result>)` - and the nice thing about `dataframe_expressions` is that the true and false results are not calculated unless they are needed (unlike true `numpy`). See the [`numpy.where` documentation](https://numpy.org/doc/stable/reference/generated/numpy.where.html) for further details. Support, of course, is dependent on the backend.
+
 ## Lambda functions and captured variables
 
 It is possible to use lambda's that capture variables, allowing combinations of objects. For example:

--- a/dataframe_expressions/utils.py
+++ b/dataframe_expressions/utils.py
@@ -1,6 +1,6 @@
 import ast
 import inspect
-from typing import Callable, Optional, TypeVar, Union
+from typing import Callable, Optional, TypeVar, Union, cast
 
 from dataframe_expressions import (
     Column, DataFrame, ast_Callable, ast_Column, ast_DataFrame,
@@ -37,6 +37,12 @@ def _term_to_ast(term: Union[int, str, DataFrame, Column, Callable],
             'Internal Error: Parent DF is required when creating a Callable'
         assert isinstance(parent_df, DataFrame)
         other_ast = ast_Callable(term, parent_df)
+    elif isinstance(term, tuple):
+        other_ast = ast.Tuple(
+            [_term_to_ast(item, parent_df) for item in cast(tuple, term)])
+    elif isinstance(term, list):
+        other_ast = ast.List(
+            [_term_to_ast(item, parent_df) for item in cast(list, term)])
     else:
         raise DataFrameTypeError("Do not know how to render a term "
                                  f"of type '{type(term).__name__}'.")

--- a/tests/test_data_frame.py
+++ b/tests/test_data_frame.py
@@ -264,6 +264,30 @@ df_3 = 1.0 / df_2
 df_4 = df_3.log10()'''
 
 
+def test_np_func_where():
+    import numpy as np
+    d = DataFrame()
+    f1 = np.where(d.x > 0, d.x, d.y)
+
+    from dataframe_expressions import dumps
+    assert '\n'.join(dumps(cast(DataFrame, f1))) == '''df_1 = DataFrame()
+df_2 = df_1.x
+df_3 = df_2 > 0
+df_4 = df_1.y
+df_5 = np_where(df_3,df_2,df_4)'''
+
+
+def test_np_func_histogram():
+    import numpy as np
+    d = DataFrame()
+    f1 = np.histogram(d.x, bins=50, range=(-0.5, 10.0))
+
+    from dataframe_expressions import dumps
+    assert '\n'.join(dumps(cast(DataFrame, f1))) == '''df_1 = DataFrame()
+df_2 = df_1.x
+df_3 = np_histogram(df_2,bins=50,range=(-0.5,10.0))'''
+
+
 def test_fluent_function_no_args():
     d = DataFrame()
     d1 = d.count()

--- a/tests/test_dump_dataframe.py
+++ b/tests/test_dump_dataframe.py
@@ -77,15 +77,23 @@ df_3 = df_1.y
 df_4 = df_2 {operator_text} df_3'''
 
 
-def test_constant():
+@pytest.mark.parametrize("constant, output", [
+    (1, "1"),
+    (1.5, "1.5"),
+    ("hi", "'hi'"),
+    ((1, 2), "(1,2)"),
+    ((), "()"),
+    ([1, 2], "[1,2]")
+])
+def test_constant(constant, output):
     df = DataFrame()
-    df1 = df.x > 1
+    df1 = df[df > constant]
 
     r = dumps(df1)
 
-    assert '\n'.join(r) == '''df_1 = DataFrame()
-df_2 = df_1.x
-df_3 = df_2 > 1'''
+    assert '\n'.join(r) == f'''df_1 = DataFrame()
+df_2 = df_1 > {output}
+df_3 = df_1[df_2]'''
 
 
 def test_string():
@@ -163,6 +171,30 @@ def test_python_other_function():
     assert '\n'.join(r) == '''df_1 = DataFrame()
 df_2 = df_1.x
 df_3 = doit(df_2)'''
+
+
+def test_python_np_function():
+    import numpy
+    df = DataFrame()
+    df1 = numpy.histogram(df.x)
+
+    r = dumps(df1)  # type: ignore
+
+    assert '\n'.join(r) == '''df_1 = DataFrame()
+df_2 = df_1.x
+df_3 = np_histogram(df_2)'''
+
+
+def test_python_kw_args():
+    import numpy
+    df = DataFrame()
+    df1 = numpy.histogram(df.x, bins=50)
+
+    r = dumps(df1)  # type: ignore
+
+    assert '\n'.join(r) == '''df_1 = DataFrame()
+df_2 = df_1.x
+df_3 = np_histogram(df_2,bins=50)'''
 
 
 def test_bogus_function_call():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,11 +3,16 @@ import pytest
 import ast
 
 
-@pytest.mark.parametrize("the_term, the_type", [(1, ast.Num), (1.5, ast.Num)])
+@pytest.mark.parametrize("the_term, the_type", [
+    (1, ast.Num),
+    (1.5, ast.Num),
+    ((-1.0, 50.0), ast.Tuple),
+    ([1, 2], ast.List),
+    ])
 def test_term_to_ast_type_check(the_term, the_type):
     assert isinstance(_term_to_ast(the_term, None), the_type)
 
 
 def test_term_to_ast_bad():
-    with pytest.raises(DataFrameTypeError) as e:
+    with pytest.raises(DataFrameTypeError):
         _term_to_ast(complex(1, 10), None)  # type: ignore


### PR DESCRIPTION

- Adds numpy array function support (fixes #1)
- Adds explicit support for `np.where`, which is like `IfExp` (fixes #15)
- Rounds out ability to dump keyword arguments
- Adds ability to translate things like lists and tuples into ast's.