### PR TITLE
Translate `numpy` functions as function calls, not extension functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ as well as some python function:
 d1 = abs(d.x)
 ```
 
-Internally, this is rendered as `d.x.sin()`. The `numpy` functions are translated directly into calls like this - it is up to whatever backend you have to actually implement them. For the complete list of `numpy` functions, see the [`numpy` math page](https://numpy.org/doc/stable/reference/routines.math.html).
+Internally, this is rendered as `sin(d.x)`. The `numpy` functions are translated directly into calls like this - it is up to whatever backend you have to actually implement them. For the complete list of `numpy` functions, see the [`numpy` math page](https://numpy.org/doc/stable/reference/routines.math.html).
 
-Finally, other `numpy` functions - `array_functions` are also translated. For example:
+Finally, other `numpy` functions - `array_functions` - are also translated. For example:
 
 ```python
 h = np.histogram(d.x, bins=50, range=(-0.5,10))

--- a/dataframe_expressions/data_frame.py
+++ b/dataframe_expressions/data_frame.py
@@ -289,7 +289,8 @@ class DataFrame:
         base_df = cast(ast_DataFrame, self.child_expr.value)
         return self.call_func(self.child_expr, base_df, inputs, kwargs)
 
-    def call_func(self, func, base_df: ast_DataFrame, inputs: Iterable[Any], kwargs: Dict[str, Any]):
+    def call_func(self, func, base_df: ast_DataFrame, inputs: Iterable[Any],
+                  kwargs: Dict[str, Any]):
         from .utils import _term_to_ast
         child_expr = ast.Call(func=func,
                               args=[_term_to_ast(a, base_df.dataframe) for a in inputs],
@@ -308,7 +309,7 @@ class DataFrame:
         '''
         self._test_for_extension('abs')
         return self.call_func(ast.Name(id='abs', ctx=ast.Load()), ast_DataFrame(self),
-                                       [self], {})
+                              [self], {})
 
     def __invert__(self) -> DataFrame:
         ''' Invert, or logical NOT operation. '''

--- a/dataframe_expressions/dump_dataframe.py
+++ b/dataframe_expressions/dump_dataframe.py
@@ -132,6 +132,7 @@ def parse_ast(a: Optional[ast.AST], context: var_context) -> List[str]:
             return f'{c.__name__}{s}'
 
         def visit_ast_Callable(self, node: ast_Callable):
+            assert node.callable is not None
             result.append(f'{context.new_df(node)} = {self._get_callable_sig(node.callable)}')
 
         def visit_Attribute(self, node: ast.Attribute):

--- a/tests/test_data_frame.py
+++ b/tests/test_data_frame.py
@@ -218,7 +218,7 @@ def test_np_sin():
     assert d1.filter is None
     assert d1.child_expr is not None
     assert ast.dump(d1.child_expr) == \
-        "Call(func=Attribute(value=ast_DataFrame(), attr='sin', ctx=Load()), args=[], keywords=[])"
+        "Call(func=Name(id='sin', ctx=Load()), args=[ast_DataFrame()], keywords=[])"
 
 
 def test_python_abs():
@@ -227,7 +227,7 @@ def test_python_abs():
     assert d1.filter is None
     assert d1.child_expr is not None
     assert ast.dump(d1.child_expr) == \
-        "Call(func=Attribute(value=ast_DataFrame(), attr='abs', ctx=Load()), args=[], keywords=[])"
+        "Call(func=Name(id='abs', ctx=Load()), args=[ast_DataFrame()], keywords=[])"
 
 
 def test_np_sin_kwargs():
@@ -237,7 +237,7 @@ def test_np_sin_kwargs():
     assert d1.filter is None
     assert d1.child_expr is not None
     assert ast.dump(d1.child_expr) == \
-        "Call(func=Attribute(value=ast_DataFrame(), attr='sin', ctx=Load()), args=[], "\
+        "Call(func=Name(id='sin', ctx=Load()), args=[ast_DataFrame()], " \
         "keywords=[keyword(arg='bogus', value=Num(n=22.0))])"
 
 
@@ -248,8 +248,8 @@ def test_np_arctan2_with_args():
     assert d1.filter is None
     assert d1.child_expr is not None
     assert ast.dump(d1.child_expr) == \
-        "Call(func=Attribute(value=ast_DataFrame(), attr='arctan2', ctx=Load()), " \
-        "args=[Num(n=100.0)], keywords=[])"
+        "Call(func=Name(id='arctan2', ctx=Load()), args=[ast_DataFrame(), " \
+        "Num(n=100.0)], keywords=[])"
 
 
 def test_np_func_with_division():
@@ -261,7 +261,7 @@ def test_np_func_with_division():
     assert '\n'.join(dumps(f1)) == '''df_1 = DataFrame()
 df_2 = df_1 - 1.0
 df_3 = 1.0 / df_2
-df_4 = df_3.log10()'''
+df_4 = log10(df_3)'''
 
 
 def test_np_func_where():

--- a/tests/test_dump_dataframe.py
+++ b/tests/test_dump_dataframe.py
@@ -155,7 +155,7 @@ def test_python_builtin_function():
 
     assert '\n'.join(r) == '''df_1 = DataFrame()
 df_2 = df_1.x
-df_3 = df_2.abs()'''
+df_3 = abs(df_2)'''
 
 
 def test_python_other_function():

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 import pytest
 
@@ -177,10 +177,11 @@ def test_xy():
 
     expr, _ = render(df1)
     assert isinstance(expr, ast.Call)
-    assert isinstance(expr.func, ast.Attribute)
-    assert expr.func.attr == 'sqrt'
-    assert isinstance(expr.func.value, ast.BinOp)
-    assert isinstance(expr.func.value.op, ast.Add)
+    assert isinstance(expr.func, ast.Name)
+    assert expr.func.id == 'sqrt'
+    assert len(expr.args) == 1
+    assert isinstance(expr.args[0], ast.BinOp)
+    assert isinstance(cast(ast.BinOp, expr.args[0]).op, ast.Add)
 
 
 def test_add_xy():
@@ -191,12 +192,12 @@ def test_add_xy():
 
     expr, _ = render(df1)
     assert isinstance(expr, ast.Call)
-    assert isinstance(expr.func, ast.Attribute)
-    assert expr.func.attr == 'sqrt'
-    assert isinstance(expr.func.value, ast.BinOp)
-    assert isinstance(expr.func.value.op, ast.Add)
+    assert isinstance(expr.func, ast.Name)
+    assert expr.func.id == 'sqrt'
+    assert isinstance(expr.args[0], ast.BinOp)
+    assert isinstance(cast(ast.BinOp, expr.args[0]).op, ast.Add)
 
-    x_component2 = expr.func.value.left
+    x_component2 = cast(ast.BinOp, expr.args[0]).left
     assert isinstance(x_component2, ast.BinOp)
     assert isinstance(x_component2.op, ast.Mult)
 


### PR DESCRIPTION
Math functions from `numpy` are now called as proper functiosn rather than extension functions.

So, `np.sin(dx.x)` is translated as just that rather than `dp.x.sin()`.

- More uniform treatment of functions, among other things
- Will make more sense to someone looking at it.