### PR TITLE
Make sure ast_Filter can be used in a Cloneing Tree Transformer

### DIFF
--- a/dataframe_expressions/render_dataframe.py
+++ b/dataframe_expressions/render_dataframe.py
@@ -16,7 +16,7 @@ class ast_Filter (ast.AST):
 
     _fields = ('expr', 'filter')
 
-    def __init__(self, expr: ast.AST, filter: ast.AST):
+    def __init__(self, expr: Optional[ast.AST] = None, filter: Optional[ast.AST] = None):
         '''
         Create a filter expression.
 

--- a/tests/test_render_dataframe.py
+++ b/tests/test_render_dataframe.py
@@ -1,4 +1,5 @@
 import ast
+from dataframe_expressions.utils_ast import CloningNodeTransformer
 from typing import Optional
 
 import pytest
@@ -524,3 +525,13 @@ def test_render_callable_twice_for_same_results():
 #     finder = find_attr()
 #     finder.visit(expr)
 #     assert len(finder.found) == 2
+
+
+def test_copy_filter():
+    a = ast_Filter(expr=ast.Name(id='a'), filter=ast.Name(id='b'))
+
+    class do_copy(CloningNodeTransformer):
+        def visit_Name(self, node: ast.Name) -> ast.Name:
+            return ast.Name(id='c')
+
+    do_copy().visit(a)


### PR DESCRIPTION

- Made ast_Filter able to have no arguments
- Added a test to double check
Fixes #28